### PR TITLE
Change user location icon color

### DIFF
--- a/index.html
+++ b/index.html
@@ -198,7 +198,7 @@
             const openingSoonIcon = createIcon('blue'); // Changed from orange to blue
             const closingSoonIcon = createIcon('orange'); // Added for closing soon
             const closedIcon = createIcon('red');
-            const userIcon = createIcon('blue');
+            const userIcon = createIcon('violet');
 
             // Geocoding was previously used to look up missing coordinates,
             // but all locations now include Latitude and Longitude in the CSV.


### PR DESCRIPTION
## Summary
- make the user "locate me" marker use a violet icon so it isn't confused with "Opening Soon"

## Testing
- `python3 -m py_compile parser.py`
- `tidy -errors index.html`

------
https://chatgpt.com/codex/tasks/task_e_6853041966188327b06e0db4d3f9a77a